### PR TITLE
moving `debug` package from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bcryptjs": "^2.4.3",
     "connect-mongo": "^3.2.0",
     "cookie-parser": "^1.4.5",
+    "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
@@ -24,7 +25,6 @@
   },
   "devDependencies": {
     "@ironh/eslint-config": "0.0.2",
-    "debug": "^4.1.1",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-import": "^2.18.2",


### PR DESCRIPTION
In effective, it is used in app.js and need to be present in production. BUT Heroku now prune the devDependencies causing the `Error: Cannot find module 'debug'` error message. See: https://devcenter.heroku.com/articles/troubleshooting-node-deploys#missing-modules